### PR TITLE
Implements replaceChild and document.head support

### DIFF
--- a/src/common/constants.js
+++ b/src/common/constants.js
@@ -21,5 +21,7 @@ export const OPS = {
     setTextContent: 9,
     addEventHandler: 10,
     removeEventHandler: 11,
-    setStyle: 12
+    setStyle: 12,
+    attachHead: 13,
+    replaceChild: 14,
 }

--- a/src/page/Dom.js
+++ b/src/page/Dom.js
@@ -2,10 +2,11 @@ import {OPS as _, WORKER_MESSAGES} from './../common/constants';
 import Channel from './../common/channel';
 import {DOCUMENT_NODE} from './../common/nodeType';
 
-var channel, container, nodes = {};
+var channel, container, head, nodes = {};
 
 export default (ctr, messageChannel) => {
     container = ctr;
+    head = document.head;
     channel = messageChannel;
     return ({operation, guid, args, guidPos = []}) => {
         guidPos.forEach(pos => args[pos] = nodes[args[pos]]);
@@ -16,6 +17,9 @@ export default (ctr, messageChannel) => {
 const DomOperations = {
     [_.attachRoot](none, id, node) {
         nodes[id] = container;
+    },
+    [_.attachHead](none, id, node) {
+        nodes[id] = head;
     },
     /// Creating new nodes
     [_.createDOMElement](id, type) {

--- a/src/page/Dom.js
+++ b/src/page/Dom.js
@@ -59,6 +59,9 @@ const DomOperations = {
     [_.insertBefore](id, newNode, refNode) {
         nodes[id].insertBefore(newNode, refNode);
     },
+    [_.replaceChild](id, newNode, node) {
+        nodes[id].replaceChild(newNode, node);
+    },
 
     // Events
     [_.addEventHandler](id, type, handler, useCapture) {

--- a/src/worker/dom/TreeNode.js
+++ b/src/worker/dom/TreeNode.js
@@ -39,8 +39,11 @@ export default class TreeNode {
         }
     }
 
-    replaceChild(node, newNode) {
-        console.log('Trying ot replace child')
+    replaceChild(newNode, node) {
+        const index = this.children.indexOf(node);
+        newNode.parentNode = this;
+        this.children[index] = newNode
+        this._bridge.send(_.replaceChild, this._guid, [newNode, node]);
     }
 
     get firstChild() {

--- a/src/worker/index.js
+++ b/src/worker/index.js
@@ -56,9 +56,11 @@ const Window = {
 
 self.window = Window;
 self.document = Document;
+self.document.head = self.document.createElement('head');
 self.topElement = self.document.createElement('div');
 self.topElement.__TOP = true;
 
+Bridge.send(_.attachHead, null, [self.document.head._guid, self.document.head]);
 Bridge.send(_.attachRoot, null, [self.topElement._guid, self.topElement]);
 
 export default self.topElement;


### PR DESCRIPTION
Implemented replaceChild, which was missing. Also added support for document.head in worker, which is used by https://github.com/webpack/style-loader and probably other libraries.