### PR TITLE
Validate touch to contain properties.

### DIFF
--- a/src/common/api/Touch.js
+++ b/src/common/api/Touch.js
@@ -1,5 +1,6 @@
 export default class Touch {
     constructor(touch) {
+      if(touch) {
         this.clientX = touch.clientX;
         this.clientY = touch.clientY;
         this.identifier = touch.identifier;
@@ -7,5 +8,6 @@ export default class Touch {
         this.pageY = touch.pageY;
         this.screenX = touch.screenX;
         this.screenY = touch.screenY;
+      }
     }
 }


### PR DESCRIPTION
touchEnd and touchCancel does not contain any properties and as such, should not expect to set any in the constructor. 