### PR TITLE
changed usage example in README.md to match API (as used in /test examples)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ The `worker.js` file is the one that now holds the actual Component.
 ```js
 // File: worker.jsx - loaded in index.html using new Worker('worker.jsx') in the file script above;
 import React from 'react';
-import ReactWorkerDOM from 'react-worker-dom/worker';
-ReactWorkerDOM.render(<Component/>);
+import ReactDOM from 'react-dom';
+import WorkerDOM from 'react-worker-dom/worker';
+ReactDOM.render(<Component/>, WorkerDOM);
 ```
 
 Look at `test\dbmonster` and `test\todoapp` directory for the examples.


### PR DESCRIPTION
When playing around with this library, I noticed the API in the usage example didn't work, and didn't line up with what I was seeing in the two example apps. This pull request tweaks the README.md file so the usage example is valid.

Thanks for the cool library!